### PR TITLE
Export a change method to bind to viewportchange events.

### DIFF
--- a/src/viewporter.js
+++ b/src/viewporter.js
@@ -26,6 +26,10 @@ var viewporter;
 
 		ready: function(callback) {
 			window.addEventListener('viewportready', callback, false);
+		},
+		
+		change: function(callback) {
+			window.addEventListener('viewportchange', callback, false);
 		}
 
 	};


### PR DESCRIPTION
So far there was a ready method exporter for binding to the viewportready event, but nothing equivalent for the viewportchange event. 

Not 100% DRY, but also not really worth abstracting the addEventListener calls either.
