### PR TITLE
Replace CrMo check with Chrome to support Chrome/Android once more

### DIFF
--- a/src/viewporter.js
+++ b/src/viewporter.js
@@ -45,7 +45,7 @@ var viewporter;
 		var that = this;
 
 		// Scroll away the header, but not in Chrome
-		this.IS_ANDROID = /Android/.test(navigator.userAgent) && !/CrMo/.test(navigator.userAgent);
+		this.IS_ANDROID = /Android/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent);
 
 		var _onReady = function() {
 


### PR DESCRIPTION
The CrMo string was removed from Chrome/Android, so for now our next-best bet is to look for just Chrome instead. The header is still fixed, so there's no point in trying to scroll anything away.
