### PR TITLE
Sane scroll check

### DIFF
--- a/src/viewporter.js
+++ b/src/viewporter.js
@@ -123,17 +123,23 @@ var viewporter;
 			window.scrollTo(0, that.IS_ANDROID ? 1 : 0); // Android needs to scroll by at least 1px
 
 			// start the checker loop
-			var iterations = this.IS_ANDROID && !deviceProfile ? 20 : 5; // if we're on Android and don't know the device, brute force hard
+			var iterations = 40;
 			var check = window.setInterval(function() {
 
 				// retry scrolling
 				window.scrollTo(0, that.IS_ANDROID ? 1 : 0); // Android needs to scroll by at least 1px
 
-				if(
-					that.IS_ANDROID
-						? (deviceProfile ? window.innerHeight === deviceProfile[orientation] : --iterations < 0) // Android: either match against a device profile, or brute force
-						: (window.innerHeight > startHeight || --iterations < 0) // iOS is comparably easy!
-				) {
+				function androidProfileCheck() {
+					return deviceProfile ? window.innerHeight === deviceProfile[orientation] : false;
+				}
+				function iosInnerHeightCheck() {
+					return window.innerHeight > startHeight;
+				}
+
+				iterations--;
+
+				// check iterations first to make sure we never get stuck
+				if ( (that.IS_ANDROID ? androidProfileCheck() : iosInnerHeightCheck()) || iterations < 0) {
 
 					// set minimum height of content to new window height
 					document.documentElement.style.minHeight = window.innerHeight + 'px';


### PR DESCRIPTION
Rewrite scroll check to always bail out at some point. Fixes Android4/Nexus S getting stuck in endless check loop. Still keeps it as short as possible by looking for height changes.
